### PR TITLE
Make sure step resolution is reset after calling SmallStepMode

### DIFF
--- a/Firmware/SparkFun_Easy_Driver_Basic_Demo/SparkFun_Easy_Driver_Basic_Demo.ino
+++ b/Firmware/SparkFun_Easy_Driver_Basic_Demo/SparkFun_Easy_Driver_Basic_Demo.ino
@@ -134,6 +134,8 @@ void SmallStepMode()
     digitalWrite(stp,LOW); //Pull step pin low so it can be triggered again
     delay(1);
   }
+  digitalWrite(MS1, LOW); // Reset to full step resolution
+  digitalWrite(MS2, LOW);
   Serial.println("Enter new option");
   Serial.println();
 }


### PR DESCRIPTION
When calling SmallStepMode(), the MS1 and MS2 bits are flipped to move the motor to 1/8th step but are not reset after that which means any further call will remain in that mode without any way to change it back.

Resetting the two bits after the call to SmallStepMode to make sure the commands behave as expected.